### PR TITLE
Return low in save, load and on function

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -93,14 +93,17 @@ low.autoSave = true
 
 low.save = (path = low.path) ->
   underdb.save low.db, path
+  low
 
 low.throttledSave = _.throttle low.save, 100
 
 low.load = (path = low.path) ->
   low.db = underdb.load path
+  low
 
 low.on = (event, listener) ->
   ee.on event, listener
+  low
 
 #
 # Expose _


### PR DESCRIPTION
For easy chain, and simplify the `require` statement. Resolve #13 .
