### PR TITLE
Changed the _.throttle call to _.debounce

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -19,7 +19,7 @@ function Store(filename) {
   return this
 }
 
-Store.prototype.save = _.throttle(function() {
+Store.prototype.save = _.debounce(function() {
   this.writer.write(stringify(this.object))
 }, 10)
 


### PR DESCRIPTION
Now it works better with batches of db operations. Previously only the first
would get persisted to disk, and the rest would be ignored.

Fixes #23
