### PR TITLE
save() method wasn't using optionally specified file.  When specified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,12 +32,12 @@ function low(file, options) {
 
   db.save = function(f) {
     f = f ? f : file
-    utils.saveAsync(file, low.stringify(obj))
+    utils.saveAsync(f, low.stringify(obj))
   }
 
   db.saveSync = function(f) {
     f = f ? f : file
-    utils.saveSync(file, low.stringify(obj))
+    utils.saveSync(f, low.stringify(obj))
   }
 
   db.object = obj

--- a/test/index.js
+++ b/test/index.js
@@ -84,10 +84,22 @@ describe('LowDB', function() {
 
   describe('sync', function() {
 
+    var file1 = 'tmp/tmp-1.json';
+    var file2 = 'tmp/tmp-2.json';
+
     beforeEach(function() {
       fs.writeFileSync(syncFile, JSON.stringify({ foo: { a: 1 } }))
       db = low(syncFile, { async: false })
-    })
+    });
+
+    afterEach(function() {
+      if (fs.existsSync(file1)) {
+        fs.unlinkSync(file1);
+      }
+      if (fs.existsSync(file2)) {
+        fs.unlinkSync(file2);
+      }
+    });
 
     describe('Autoload', function() {
       it('loads automatically file', function() {
@@ -118,6 +130,20 @@ describe('LowDB', function() {
         assert.deepEqual(JSON.parse(fs.readFileSync(syncFile)), db.object)
       })
     })
+
+    describe('#saveSync(... with filename ...)', function() {
+      it('should write a different file from the initial db file specified.', function() {
+        db = low(file1, { async: false });
+        db('file-names').push({name:'first'});
+        db.saveSync();
+
+        assert(fs.existsSync(file1));
+
+        db.saveSync(file2);
+        assert(fs.existsSync(file2));
+      })
+
+    });
 
   })
 


### PR DESCRIPTION
the code used the filename specified on the db creation.  These
changes use the filename if provided otherwise the originally
configured db.json file name.  These updates apply to both sync and
async saves, but only sync were tested since the API doesn't include a
callback mechanism for the async file write (yet).