### PR TITLE
Fix handling of empty files

### DIFF
--- a/src/disk.js
+++ b/src/disk.js
@@ -14,7 +14,7 @@ module.exports = {
   read: function (file) {
     if (fs.existsSync(file)) {
       var buf = fs.readFileSync(file)
-      return (buf || '').toString().trim()
+      return buf ? buf.toString().trim() : ''
     }
   },
 

--- a/src/disk.js
+++ b/src/disk.js
@@ -12,7 +12,10 @@ function getTempFile(file) {
 
 module.exports = {
   read: function (file) {
-    if (fs.existsSync(file)) return fs.readFileSync(file)
+    if (fs.existsSync(file)) {
+      var buf = fs.readFileSync(file)
+      return (buf || '').toString().trim()
+    }
   },
 
   write: function(file, data) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-var fs = require('fs')
 var _ = require('lodash')
 var disk = require('./disk')
 
@@ -59,10 +58,11 @@ function low(file, options) {
   }
 
   function db(key) {
+    var array
     if (db.object[key]) {
-      var array = db.object[key]
+      array = db.object[key]
     } else {
-      var array = db.object[key] = []
+      array = db.object[key] = []
       save()
     }
 
@@ -91,7 +91,11 @@ function low(file, options) {
       try {
         db.object = low.parse(data)
       } catch (e) {
+        if (e instanceof SyntaxError) {
+          e.message = 'The "' + file + '" database is corrupted (malformed JSON)';
+        } else {
         e.message += ' in file:' + file
+        }
         throw e
       }
     } else {

--- a/test/index.js
+++ b/test/index.js
@@ -220,6 +220,22 @@ describe('LowDB', function() {
     })
 
   })
+  describe('empty database', function() {
+    it('load non existing file', function() {
+      if (fs.existsSync(syncFile)) {
+        fs.unlinkSync(syncFile)
+      }
+      assert.doesNotThrow(low(syncFile, { async: false }))
+    })
+    it('load an empty file', function() {
+      fs.writeFileSync(syncFile, '')
+      assert.doesNotThrow(low(syncFile, { async: false }))
+    })
+    it('load a file containing only whitespace', function() {
+      fs.writeFileSync(syncFile, '\n\t ')
+      assert.doesNotThrow(low(syncFile, { async: false }))
+    })
+  })
 })
 
 describe('underscore-db', function() {


### PR DESCRIPTION
This is a suggested fix for typicode/lowdb#36.
Opening an empty file or a file that contains only whitespace will act exactly the same as opening a non existing file (before this change you would have gotten an exception).