### PR TITLE
Replace fs with graceful-fs in disk.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "homepage": "https://github.com/typicode/lowdb",
   "dependencies": {
     "lodash": "^3.1.0",
-    "steno": "^0.4.1"
+    "steno": "^0.4.1",
+    "graceful-fs": "^3.0.8"
   },
   "devDependencies": {
     "husky": "^0.7.0",

--- a/src/disk.js
+++ b/src/disk.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var steno = require('steno')
 
 module.exports = {


### PR DESCRIPTION
The read function that is exported from disk.js, uses the `fs.readFileSync` function which internally uses fs.readSync. The `fs.readSync` function can fail from time to time and return the following error:
`EAGAIN, resource temporarily unavailable`
graceful-fs patches fs.readSync so it will retry on the EAGAIN error, thus increasing the reliability of `disk.read`.