### PR TITLE
Lazy creation of db file and exists method

### DIFF
--- a/src/disk.js
+++ b/src/disk.js
@@ -16,5 +16,8 @@ module.exports = {
 
   writeSync: function (file, data) {
     steno.writeFileSync(file, data)
+  },
+  exists: function (file) {
+    return fs.existsSync(file)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -110,8 +110,6 @@ function low (file, options) {
         e.message += ' in file:' + file
         throw e
       }
-    } else {
-      db.saveSync()
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -128,4 +128,7 @@ low.parse = function (str) {
   return JSON.parse(str)
 }
 
+low.exists = function(file) {
+  return disk.exists(file)
+}
 module.exports = low

--- a/src/index.js
+++ b/src/index.js
@@ -101,8 +101,8 @@ function low (file, options) {
   db.object = {}
 
   if (file) {
-    var data = disk.read(file)
-    if (data && data.trim() !== '') {
+    var data = (disk.read(file) || '').trim()
+    if (data) {
       try {
         db.object = low.parse(data)
       } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,8 @@ low.parse = function (str) {
   return JSON.parse(str)
 }
 
-low.exists = function(file) {
+low.exists = function (file) {
   return disk.exists(file)
 }
+
 module.exports = low

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var assert = require('assert')
 var sinon = require('sinon')
 var rmrf = require('rimraf')
@@ -233,6 +233,20 @@ describe('LowDB', function () {
     it('loads a file with whitespaces', function () {
       fs.writeFileSync(syncFile, '\n\t ')
       assert.doesNotThrow(low(syncFile, { async: false }))
+    })
+
+  })
+
+  describe('file lazy creation and exists', function () {
+
+    it('lazy create file', function () {
+      if (fs.existsSync(syncFile)) {
+        fs.unlinkSync(syncFile)
+      }
+      var db = low(syncFile, { async: false })
+      assert(!low.exists(syncFile))
+      db.saveSync()
+      assert(low.exists(syncFile))
     })
 
   })


### PR DESCRIPTION
This PR adds the following:
1. If the db file doesn't exist, it will be created only after the first db.save.
2. New method to check if the db exists. `low.exists(file)`.