### PR TITLE
Refactor initial data load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,8 +101,8 @@ function low (file, options) {
   db.object = {}
 
   if (file) {
-    var data = disk.read(file)
-    if (data && data.trim() !== '') {
+    var data = (disk.read(file) || '').trim()
+    if (data) {
       try {
         db.object = low.parse(data)
       } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -87,10 +87,10 @@ function low (file, options) {
   db.object = {}
 
   if (file) {
-    var data = disk.readSync(file)
     // Parse file if there's some data
     // Otherwise init file
-    if (data && data.trim() !== '') {
+    var data = (disk.readSync(file) || '').trim()
+    if (data) {
       try {
         db.object = low.parse(data)
       } catch (e) {


### PR DESCRIPTION
disk.readSync returns a Buffer. JSON.parse (used through low.parse) expects a string, so if given something that is not a string, such as a Buffer, it implicitly converts it to string using toString.
In the former code, we would have 2 conversions from Buffer to string. The first conversion is due the data.trim in the condition (line 93) and the second conversion is when calling JSON.parse (through low.parse in line 95).
In this commit we change it to a single conversion (we trim the Buffer which implicitly converts it to a string and assign the output directly into the data variable, so there's no need for a second conversion on JSON.parse).

This is a small change that can make loading big db files a bit more efficient.
The code remains readable and it's arguably clearer what the data variable holds.