### PR TITLE
Show helpful errors when JSON parsing fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
   },
   "homepage": "https://github.com/typicode/lowdb",
   "dependencies": {
+    "graceful-fs": "^3.0.8",
+    "json-parse-helpfulerror": "^1.0.3",
     "lodash": "^3.1.0",
-    "steno": "^0.4.1",
-    "graceful-fs": "^3.0.8"
+    "steno": "^0.4.1"
   },
   "devDependencies": {
     "husky": "^0.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ function low (file, options) {
       try {
         db.object = low.parse(data)
       } catch (e) {
-        if (e instanceof SyntaxError) e.message = 'Malformed JSON in file: ' + file + '\n' + e.message;
+        if (e instanceof SyntaxError) e.message = 'Malformed JSON in file: ' + file + '\n' + e.message
         throw e
       }
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 var lodash = require('lodash')
 var disk = require('./disk')
+var jph = require('json-parse-helpfulerror')
 
 // Returns a lodash chain that calls .value() and cb()
 // automatically after the first .method()
@@ -94,8 +95,7 @@ function low (file, options) {
       try {
         db.object = low.parse(data)
       } catch (e) {
-        if (e instanceof SyntaxError) e.message = 'Malformed JSON'
-        e.message += ' in file:' + file
+        if (e instanceof SyntaxError) e.message = 'Malformed JSON in file: ' + file + '\n' + e.message;
         throw e
       }
     } else {
@@ -111,7 +111,7 @@ low.stringify = function (obj) {
 }
 
 low.parse = function (str) {
-  return JSON.parse(str)
+  return jph.parse(str)
 }
 
 module.exports = low


### PR DESCRIPTION
Added the `json-parse-helpfulerror` module (the same one that npm uses), that provides helpful errors when failing to parse JSONs.

It's important to note that the actual parsing is still done by the fast native JSON.parse. Only if it failed and throw and error, the module analysis what caused it and outputs a more meaningful error that shows you the token where it failed, including line and column numbers.

It some what relates to the discussion on #36.