### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ db('songs')
 Retrieve song titles.
 
 ```javascript
-db('songs').pluck('titles')
+db('songs').pluck('title')
 ```
 
 Get the number of songs.


### PR DESCRIPTION
`db('songs').pluck('titles')` would return an array of undefined.