### PR TITLE
add the Promise option to lowdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/*.log
 node_modules
 tmp
+.idea
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 .travis.yml
 test
+.idea
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "graceful-fs": "^3.0.8",
     "json-parse-helpfulerror": "^1.0.3",
     "lodash": "^3.1.0",
-    "steno": "^0.4.1"
+    "steno": "^0.4.1",
+    "q": "^1.4.1"
   },
   "devDependencies": {
     "husky": "^0.9.0",

--- a/src/disk.js
+++ b/src/disk.js
@@ -1,5 +1,6 @@
 var fs = require('graceful-fs')
 var steno = require('steno')
+var Q = require('q')
 
 module.exports = {
   // No async read
@@ -17,5 +18,18 @@ module.exports = {
 
   writeSync: function (file, data) {
     steno.writeFileSync(file, data)
+  },
+
+  writePromise: function (file, data) {
+    var deferred = Q.defer()
+    steno.writeFile(file, data, function(err){
+      if (err) {
+        deferred.reject(new Error(error))
+      } else {
+        deferred.resolve('success')
+      }
+    })
+    return deferred.promise
   }
+
 }

--- a/src/disk.js
+++ b/src/disk.js
@@ -22,7 +22,7 @@ module.exports = {
 
   writePromise: function (file, data) {
     var deferred = Q.defer()
-    steno.writeFile(file, data, function(err){
+    steno.writeFile(file, data, function (err) {
       if (err) {
         deferred.reject(new Error(error))
       } else {

--- a/src/disk.js
+++ b/src/disk.js
@@ -24,7 +24,7 @@ module.exports = {
     var deferred = Q.defer()
     steno.writeFile(file, data, function (err) {
       if (err) {
-        deferred.reject(new Error(error))
+        deferred.reject(new Error(err))
       } else {
         deferred.resolve('success')
       }

--- a/src/index.js
+++ b/src/index.js
@@ -34,12 +34,12 @@ function low (file, options) {
     async: true,
     promise: false
   }, options)
-  
+
   // Modify value function to call save before returning result
   var value = _.prototype.value
   _.prototype.value = function () {
     var res = value.apply(this, arguments)
-    if(options.promise){
+    if (options.promise) {
       return save().then(
         function () {
           return res
@@ -49,8 +49,8 @@ function low (file, options) {
         }
       )
     } else {
-    save()
-    return res
+      save()
+      return res
     }
   }
 
@@ -64,7 +64,7 @@ function low (file, options) {
       if (str === checksum) {
         if (options.promise) {
           return Q.fcall(function () {
-            return 'no changes';
+            return 'no changes'
           })
         } else {
           return
@@ -72,7 +72,7 @@ function low (file, options) {
       }
       checksum = str
       if (options.async) {
-        if (options.promise){
+        if (options.promise) {
           return disk.writePromise(file, str)
         } else {
           disk.write(file, str)
@@ -82,8 +82,6 @@ function low (file, options) {
       }
     }
   }
-
-
 
   function db (key) {
     var array
@@ -111,7 +109,7 @@ function low (file, options) {
     disk.writeSync(f, low.stringify(db.object))
   }
 
-  db.savePromise = function(f){
+  db.savePromise = function (f) {
     f = f ? f : file
     return disk.writePromise(f, low.stringify(db.object))
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,19 @@ function low (file, options) {
   var value = _.prototype.value
   _.prototype.value = function () {
     var res = value.apply(this, arguments)
+    if(options.promise){
+      return save().then(
+        function () {
+          return res
+        },
+        function (err) {
+          throw err
+        }
+      )
+    } else {
     save()
     return res
+    }
   }
 
   // db.object checksum


### PR DESCRIPTION
Hello typicode:

It has been a while since I use lowdb as my main json db. It is pretty great and works smoothly with all my projects. The only improvement I would like you to take a look at is the support for JavaScript's promise feature.

**In a word, promise support is added to lowdb.**
```javascript
  options = _.assign({
    autosave: true,
    async: true,
    promise: false
  }, options)
```
1. add function `writePromise()` in disk.js. 
2. add function `db.savePromise()` in index.js. 
3. modify function `_.prototype.value()`  and `save()` in index.js.

All of the modifications above are intended to implement the promise feature. As long as the promise option is set to true, the value() will return a promise:
```javascript
if(options.promise){
  return save().then(
     function () {
       return res
      },
     function (err) {
        throw err
      }
  )
}
```
Besides, the modification to function save() is similar to that to value(). **If promise option is true, it returns a promise. Otherwise everything is the same as the original lowdb**.

These changes enables users to use promise(powered by Q module https://github.com/kriskowal/q ) with lowdb, **compatible with the original lowdb at the same time**.

I have used the modified version in my own development for my university's websites and it is reliable.
Looking forward to "merge".

Regards,
Fatea