### PR TITLE
Fix issue with an observable db.object assigning to itself

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ function low (source, options = {}, writeOnChange = true) {
 
   function db (key) {
     if (typeof db.object[key] === 'undefined') {
-        db.object[key] = []
+      db.object[key] = []
     }
     let array = db.object[key]
     let short = lowChain(_, array, _save)

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,10 @@ function low (source, options = {}, writeOnChange = true) {
   }
 
   function db (key) {
-    let array = db.object[key] = db.object[key] || []
+    if (typeof db.object[key] === 'undefined') {
+        db.object[key] = []
+    }
+    let array = db.object[key]
     let short = lowChain(_, array, _save)
     short.chain = () => _.chain(array)
     return short


### PR DESCRIPTION
Fixes issue with db.object assigning to itself while using observable objects.

When using a lowdb *source* created from observable libraries such as [mobservable](https://github.com/mweststrate/mobservable) and accessing *lowdb* from inside an observer object, all hell breaks lose.

The test case is pretty difficult to write since it requires a bunch of libraries but the fix is simple.

Could this be included quickly and next version pushed ? I need it :)

Thanks!