### PR TITLE
Make format option work

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,10 +300,8 @@ const myStorage = {
 }
 
 const myFormat = {
-  format: {
-    serialize: (obj) => // must return data (usually string)
-    deserialize: (data) => // must return an object
-  }
+  serialize: (obj) => // must return data (usually string)
+  deserialize: (data) => // must return an object
 }
 
 low(source, {

--- a/src/_index.js
+++ b/src/_index.js
@@ -38,7 +38,6 @@ module.exports = function (source, {
     }
 
     if (format) {
-      const { format } = options
       db.serialize = format.serialize
       db.deserialize = format.deserialize
     }

--- a/src/index.node.js
+++ b/src/index.node.js
@@ -2,6 +2,8 @@ const lodash = require('lodash')
 const index = require('./_index')
 const storage = require('./file-sync')
 
-module.exports = function low(source, opts = { storage }) {
+module.exports = function low(source, opts = {}) {
+  opts.storage = opts.storage || storage
+
   return index(source, opts, lodash)
 }


### PR DESCRIPTION
There are 3 things happening here

1. Remove `const { format } = options`, and make format option work
2. Don't overwrite the storage if I only want to change the formatting
3. Fix the readme

Fixes https://github.com/typicode/lowdb/issues/116
