### PR TITLE
Removed usage of graceful-fs and file-exists check in file-sync.js

### DIFF
--- a/src/file-sync.js
+++ b/src/file-sync.js
@@ -1,24 +1,25 @@
-const fs = require('graceful-fs')
+const fs = require('fs')
 const { parse, stringify } = require('./json')
 
 module.exports = {
   read: (source, deserialize = parse) => {
-    if (fs.existsSync(source)) {
-      // Read database
-      const data = fs.readFileSync(source, 'utf-8').trim() || '{}'
-
-      try {
-        return deserialize(data)
-      } catch (e) {
-        if (e instanceof SyntaxError) {
-          e.message = `Malformed JSON in file: ${source}\n${e.message}`
-        }
-        throw e
-      }
-    } else {
+    let data = '{}'
+    
+    try {
+      // Read existing database
+      data = fs.readFileSync(source, 'utf-8').trim() || data
+    } catch (e) {
       // Initialize empty database
-      fs.writeFileSync(source, '{}')
-      return {}
+      fs.writeFileSync(source, data)
+    }
+    
+    try {
+      return deserialize(data)
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        e.message = `Malformed JSON in file: ${source}\n${e.message}`
+      }
+      throw e
     }
   },
   write: (dest, obj, serialize = stringify) => {


### PR DESCRIPTION
- No graceful-fs necessary
- No file-exists check needed
- Just one return

It's untested, but should work. What do you think?
