### PR TITLE
lowdb.d.ts: export Low and LowFactory instead of only LowFactory

### DIFF
--- a/lowdb.d.ts
+++ b/lowdb.d.ts
@@ -525,6 +525,7 @@ interface LowFactory {
   new (source?: string, opts?: Options): Low;
 }
 
-declare var low: LowFactory;
+declare var lowFactory: LowFactory;
 
-export = low
+export { Low }
+export { lowFactory as LowFactory}


### PR DESCRIPTION
As of now, lowdb.d.ts only export `LowFactory` interface, which is the constructor function for lowdb objects.

In typescript, you need to declare variable types (or "interfaces" for class instances/objects), in this file, the `Low` interface has been written to define any object created by LowFactory.

The problem is that the file does not export `Low` interface so I cannot use it in my code, I have to use `any` type in order to use lowdb object methods: 

```typescript
import LowFactory from "lowdb";
let db: any = new LowFactory();
db.setState({test: "test"});
console.log(db.getState());
```
Which is a bad practice in TypeScript world.
I also lose auto-completion features in my editor because of the use of "any".

The change I made is to export both `Low` and `LowFactory` so that I can declare variables as `Low` interface:

```typescript
import {Low, LowFactory} from "lowdb";
let db: Low = new LowFactory();
db.setState({test: "test"});
console.log(db.getState());
```