### PR TITLE
Fix typo in _.protoype.value() -> _.prototype.value()

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ __db.[...].write()__ and __db.[...].value()__
 
 `write()` writes database to state.
 
-On the other hand, `value()` is just [\_.protoype.value()](https://lodash.com/docs/4.17.4#prototype-value) and should be used to execute a chain that doesn't change database state.
+On the other hand, `value()` is just [\_.prototype.value()](https://lodash.com/docs/4.17.4#prototype-value) and should be used to execute a chain that doesn't change database state.
 
 
 ```js


### PR DESCRIPTION
Fix typo in _.protoype.value() -> _.prototype.value() in readme