### PR TITLE
Fixed broken lodash-id examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,18 +323,25 @@ const post = db
 
 ```js
 const lodashId = require('lodash-id')
-const db = low('db.json')
+const FileSync = require('lowdb/adapters/FileSync')
+
+const adapter = new FileSync('db.json')
+const db = low(adapter)
 
 db._.mixin(lodashId)
 
-const post = db
+// We need to set some default values, if the collection does not exist yet
+// We also can store our collection
+const collection = db
+  .defaults({ posts: [] })
   .get('posts')
+
+const newPost = collection
   .insert({ title: 'low!' })
   .write()
 
-const post = db
-  .get('posts')
-  .getById(post.id)
+const oldPost = collection
+  .getById(newPost.id)
   .value()
 ```
 


### PR DESCRIPTION
Hi there,

I fixed some issues with the provided examples:

1. `Error: An adapter must be provided, see https://github.com/typicode/lowdb/#usage`
2. We should use two variables here, you can't redeclare a const variable (not copy and paste friendly)
3. Added storing of the collection to the example, as it shows an slightly advanced use case
4. It took me some time to understand, we **need** default values.

About the 3rd: The whole default thing should be placed **way** more prominent in the `README.md`.
It took me some time to figure. Without defaults, the lowdb seems pretty useless (as it doesn't work for me at all).
This might be some mistake on my side, so you might ignore my opinion here. :)

Regards!