### PR TITLE
chore(examples): Fix fp example add adapter

### DIFF
--- a/examples/fp.md
+++ b/examples/fp.md
@@ -11,8 +11,10 @@ It can help reducing the size of your `bundle.js`
 ```js
 import low from 'lowdb/lib/fp'
 import { concat, find, sortBy, take, random } from 'lodash/fp'
+import FileSync from 'lowdb/adapters/FileSync'
 
-const db = low()
+const adapter = new FileSync('db.json')
+const db = low(adapter)
 
 // Get posts
 const defaultValue = []


### PR DESCRIPTION
 * Add missing `adapter`.


 * Calling `low()` with no adapter fails with the following traces as there is no default adapter inside https://github.com/typicode/lowdb/blob/b7eff57a99ef8662ad86e5895ded4b96dfe2137a/src/fp.js#L6 nor https://github.com/typicode/lowdb/blob/b7eff57a99ef8662ad86e5895ded4b96dfe2137a/src/common.js#L3

```sh
/Users/alvaropinot/work/alvaropinot/XXX/node_modules/lowdb/lib/common.js:7
    var r = adapter.read();
                    ^

TypeError: Cannot read property 'read' of undefined
    at Function.db.read (/Users/alvaropinot/work/alvaropinot/XXX/node_modules/lowdb/lib/common.js:7:21)
    at Object.init (/Users/alvaropinot/work/alvaropinot/XXX/node_modules/lowdb/lib/common.js:36:13)
    at module.exports (/Users/alvaropinot/work/alvaropinot/XXX/node_modules/lowdb/lib/fp.js:24:17)
    at Object.<anonymous> (/Users/alvaropinot/work/alvaropinot/XXX/index.js:15:12)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)
    at Module.load (internal/modules/cjs/loader.js:589:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:528:12)
    at Function.Module._load (internal/modules/cjs/loader.js:520:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:719:10)
```

---
## Q&A

**Should a default value for adapter exits? If so is there any sane default for both browser and server?**