### PR TITLE
Allow database type to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,18 +260,14 @@ const db = new Low(adapter)
 
 ### Using it with TypeScript
 
-Lowdb now comes with definitions files out of the box, but there's only `data` that isn't typed because lowdb can't know what your data structure will be. To let know TypeScript what your data structure is you can extend Low like below:
+Lowdb now comes with definitions files out of the box, but since there's no way of telling what the data will look like you will need to provide an interface via a generic. 
 
 ```ts
 interface IData {
   messages: string[]
 }
 
-class TypedData extends Low {
-  data: IData
-}
-
-const db = new Low(adapter) as TypedData
+const db = new Low<IData>(adapter)
 ```
 
 ## Limits

--- a/src/Low.ts
+++ b/src/Low.ts
@@ -5,9 +5,9 @@ export interface IAdapter {
   write: (data: any) => Promise<void>
 }
 
-export default class Low {
+export default class Low<T = any> {
   public adapter: IAdapter
-  public data: any
+  public data?: T
 
   constructor(adapter: IAdapter) {
     if (adapter) {

--- a/src/LowSync.ts
+++ b/src/LowSync.ts
@@ -5,9 +5,9 @@ export interface ISyncAdapter {
   write: (data: any) => void
 }
 
-export default class Low {
+export default class Low<T = any> {
   public adapter: ISyncAdapter
-  public data: any
+  public data?: T
 
   constructor(adapter: IAdapter) {
     this.adapter = adapter


### PR DESCRIPTION
By adding a generic type parameter when initialising the database, we get full type safety when querying. The default is still any so this is not a breaking change. :slightly_smiling_face: 

This allows for something like this:

```ts
interface Post {
  id: string;
  [key: string]: string;
}
interface PostsDB {
  posts: Post[];
}

const adapter = new JSONFile("db.json");
const db = new Low<PostsDB>(adapter);
```
