### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ class MyStorage {
 }
 
 const adapter = new MyStorage(args)
-const db = low()
+const db = low(adapter)
 ```
 
 See [src/adapters](src/adapters) for examples.


### PR DESCRIPTION
On the title 'How to create custom adapters' there should be a parameter to pass to 'low()', it was added.