### PR TITLE
Modify misleading comment

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -92,7 +92,7 @@ low(adapter)
 
 ## In-memory
 
-With this adapter, calling `write` will do nothing. One use case for this adapter can be for tests.
+With this adapter, calling `write` has the same effect as calling `value`. One use case for this adapter can be for tests.
 
 ```js
 const fs = require('fs')


### PR DESCRIPTION
I was misled by this comment when trying to use Memory as a test mock for a file-based DB.

It's not true that calling `write` has no effect. Indeed if you don't call either `write` or `value` at the end of a chain (as described by https://lodash.com/docs/4.17.15#chain ) then the changes to db state authored within a chain are lost.
