### PR TITLE
Clarify usage of `db.setState` (must use `.write()` too!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ Returns database state.
 db.getState() // { posts: [ ... ] }
 ```
 
-__db.setState(newState)__
+__db.setState(newState).write()__
 
 Replaces database state.
 
 ```js
 const newState = {}
-db.setState(newState)
+db.setState(newState).write()
 ```
 
 __db.write()__


### PR DESCRIPTION
Hello, I've been struggling for a while with `lowdb` and `jest` - the database state just wouldn't be correctly set.

After a while, I finally found out that when I call `db.setState()`, I must also call `.write()` on top of it!

```diff
-db.setState()
+db.setState().write()
```

Note that I'm using the FileAsync adapter. I don't know if you're actually supposed to call `.write()` everytime you call `.setState()` & want to commit it, but that's what fixes issues for me.
This could also be a bug - I'm not sure, and @typicode or someone else will have to verify.

The worst thing is, is that without calling `.write`, everything still seemed to work, except for the tests with jest!