### PR TITLE
Failed to close the database instance on example code

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -87,7 +87,7 @@ low(adapter)
   })
   .then(() => {
     app.listen(3000, () => console.log('listening on port 3000'))
-  })
+  )})
 ```
 
 ## In-memory


### PR DESCRIPTION
A parenthesis is missing before the brace to close the app.listen(