### PR TITLE
Support "main" index file for non-module environments and flat import

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Tiny local JSON database for Node, Electron and the browser",
   "type": "module",
+  "main": "./lib/index.js",
   "exports": "./lib/index.js",
   "files": [
     "lib",


### PR DESCRIPTION
Closes #462. Closes #471.

Implements "main" which is required when your primary export file is not `<root>/index.js`. See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main