### PR TITLE
Fixed issue with the usage guide in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ npm install lowdb
 ## Usage
 
 ```js
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { Low, JSONFile } from 'lowdb'
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Use JSON file for storage
 const file = join(__dirname, 'db.json')
@@ -82,6 +85,7 @@ await db.read()
 // If file.json doesn't exist, db.data will be null
 // Set default data
 db.data ||= { posts: [] }
+// db.data = db.data || { posts: [] } // for node < v15.x
 
 // Create and query items using plain JS
 db.data.posts.push('hello world')


### PR DESCRIPTION
Based on https://nodejs.org/api/esm.html#esm_no_filename_or_dirname , there is no __dirname available in ES modules in node.js. I edited the usage guide in the README.md file. Also Logical OR assignment (||=) is not supported in node.js v15.x lower, I added a comment to help with that too.