### PR TITLE
Fixed issue with importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lowdb",
   "version": "3.0.0",
   "description": "Tiny local JSON database for Node, Electron and the browser",
+  "main": "./lib/index.js",
   "keywords": [
     "database",
     "db",


### PR DESCRIPTION
I had just installed this package, but I was unable to import it.
```js
import { LowSync } from 'lowdb'
```
It kept failing with
```
Cannot find module: 'lowdb'. Make sure this package is installed.

You can install this package by running: npm install lowdb.
```
I tried reinstalling it, deleting `node_modules` and then installing, nothing worked. Eventually, I saw that you can add `"main": "./lib/index.js",` to the `package.json` in the `lowdb` folder. I did that and it worked. So I'm just making this PR to hopefully fix it.