### PR TITLE
Re-introduce main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lowdb",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Tiny local JSON database for Node, Electron and the browser",
   "keywords": [
     "database",
@@ -28,6 +28,7 @@
   "author": "Typicode <typicode@gmail.com>",
   "type": "module",
   "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "types": "lib",
   "files": [
     "lib",
@@ -45,7 +46,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "steno": "^2.1.0"
+    "steno": "^2.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
I believe we should add "main" field to the `package.json` for this repository. This will also need to be done for the dependency "steno" which is in a PR [here](https://github.com/typicode/steno/pull/23). The version in both this and steno's PR have been bumped as a patch, and this PR now references that patch of steno.

# Why

Aside from the fact that **nodejs.org** advises to do so [here](https://nodejs.org/api/packages.html#main-entry-point-export)...

> it is advisable to define both "exports" and "main" in the package’s package.json

I'm also having trouble importing LowDB in a common project: a Create React App project. I presume the real problem is with Create React App's usage of Webpack 5, and it seemingly ignoring (or not properly implementing) the `"exports"` field in a module's `package.json`.

# Recreating the issue is easy...

1) Create a CRA:

```
$ yarn create react-app my-app --template typescript
```

2) Navigate to project and install LowDB

```
$ cd my-app && yarn add lowdb
```

3) Import LowDB in some file, e.g `src/index.ts`:

```
import { Low } from 'lowdb'

console.log(Low)
```

4) Try and build/run:

```
$ yarn build
```

Command fails with:

> Cannot find module: 'lowdb'. Make sure this package is installed.

The reason is that Webpack doesn't know how to find the package when it is bundling everything together. Running `yarn list lowdb` is a false-positive.

# Testing the fix...

Simply find `lowdb` in the `node_modules` of the `my-app` CRA that you've just created and add `"main": "./lib/index.js"`. You will also need to do the same with `steno`.

Then run `yarn build` and all is well...

# Win win

I think this is a pretty straight forward addition and will probably help a lot of people out who are using Webpack to bundle.

There is a hack which is to use LowDB by importing the `lib` subdirectory (`import { Low } from 'lowdb/lib`), but this isn't sufficient when you're bundling other modules that _do_ have the correct import syntax and a good bundler. So a big monorepo project suffers. So I think it's just easier/safer to include a "main" field in `package.json`.

Until this is resolved I will have to use a forked version of this library, and `steno`, which is a shame.