### PR TITLE
fix: assign type 'Promise<void>' to type 'never'

### DIFF
--- a/src/adapters/TextFile.test.ts
+++ b/src/adapters/TextFile.test.ts
@@ -22,7 +22,7 @@ export async function testTextFile() {
 export async function testRaceCondition() {
   const filename = tempy.file()
   const file = new TextFile(filename)
-  const promises = []
+  const promises: Promise<void>[] = []
 
   let i = 0
   for (; i <= 100; i++) {


### PR DESCRIPTION
```
error TS2345: Argument of type 'Promise<void>' is not assignable to parameter of type 'never'
```