### PR TITLE
fix: pass eslint

### DIFF
--- a/src/Low.test.ts
+++ b/src/Low.test.ts
@@ -17,16 +17,14 @@ function createJSONFile(obj: unknown): string {
   return file
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
-export async function testNoAdapter() {
+export function testNoAdapter(): void {
   // Ignoring TypeScript error and pass incorrect argument
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   throws(() => new Low(), MissingAdapterError)
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function testLow() {
+export async function testLow(): Promise<void> {
   type Data = {
     a?: number
     b?: number
@@ -54,8 +52,7 @@ export async function testLow() {
   deepEqual(JSON.parse(data), newObj)
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function testLodash() {
+export async function testLodash(): Promise<void> {
   // Extend with lodash
   class LowWithLodash<T> extends Low<T> {
     chain: lodash.ExpChain<this['data']> = lodash.chain(this).get('data')

--- a/src/Low.test.ts
+++ b/src/Low.test.ts
@@ -17,6 +17,7 @@ function createJSONFile(obj: unknown): string {
   return file
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
 export async function testNoAdapter() {
   // Ignoring TypeScript error and pass incorrect argument
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -24,6 +25,7 @@ export async function testNoAdapter() {
   throws(() => new Low(), MissingAdapterError)
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function testLow() {
   type Data = {
     a?: number
@@ -52,6 +54,7 @@ export async function testLow() {
   deepEqual(JSON.parse(data), newObj)
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function testLodash() {
   // Extend with lodash
   class LowWithLodash<T> extends Low<T> {

--- a/src/LowSync.test.ts
+++ b/src/LowSync.test.ts
@@ -12,6 +12,7 @@ function createJSONFile(obj: unknown): string {
   return file
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
 export async function testNoAdapter() {
   // Ignoring TypeScript error and pass incorrect argument
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -19,6 +20,7 @@ export async function testNoAdapter() {
   throws(() => new LowSync(), MissingAdapterError)
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
 export async function testLowSync() {
   type Data = {
     a?: number

--- a/src/LowSync.test.ts
+++ b/src/LowSync.test.ts
@@ -12,16 +12,14 @@ function createJSONFile(obj: unknown): string {
   return file
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
-export async function testNoAdapter() {
+export function testNoAdapter(): void {
   // Ignoring TypeScript error and pass incorrect argument
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   throws(() => new LowSync(), MissingAdapterError)
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
-export async function testLowSync() {
+export function testLowSync(): void {
   type Data = {
     a?: number
     b?: number

--- a/src/adapters/JSONFile.test.ts
+++ b/src/adapters/JSONFile.test.ts
@@ -3,8 +3,7 @@ import tempy from 'tempy'
 
 import { JSONFile } from './JSONFile.js'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function testJSONFile() {
+export async function testJSONFile(): Promise<void> {
   const obj = { a: 1 }
 
   const filename = tempy.file()

--- a/src/adapters/JSONFile.test.ts
+++ b/src/adapters/JSONFile.test.ts
@@ -3,6 +3,7 @@ import tempy from 'tempy'
 
 import { JSONFile } from './JSONFile.js'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function testJSONFile() {
   const obj = { a: 1 }
 

--- a/src/adapters/JSONFileSync.test.ts
+++ b/src/adapters/JSONFileSync.test.ts
@@ -3,8 +3,7 @@ import tempy from 'tempy'
 
 import { JSONFileSync } from './JSONFileSync.js'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
-export async function testJSONFileSync() {
+export function testJSONFileSync(): void {
   const obj = { a: 1 }
 
   const filename = tempy.file()

--- a/src/adapters/JSONFileSync.test.ts
+++ b/src/adapters/JSONFileSync.test.ts
@@ -3,6 +3,7 @@ import tempy from 'tempy'
 
 import { JSONFileSync } from './JSONFileSync.js'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
 export async function testJSONFileSync() {
   const obj = { a: 1 }
 

--- a/src/adapters/LocalStorage.test.ts
+++ b/src/adapters/LocalStorage.test.ts
@@ -21,6 +21,7 @@ global.localStorage = {
   },
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
 export async function testLocalStorage() {
   const obj = { a: 1 }
   const storage = new LocalStorage('key')

--- a/src/adapters/LocalStorage.test.ts
+++ b/src/adapters/LocalStorage.test.ts
@@ -21,8 +21,7 @@ global.localStorage = {
   },
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
-export async function testLocalStorage() {
+export function testLocalStorage(): void {
   const obj = { a: 1 }
   const storage = new LocalStorage('key')
 

--- a/src/adapters/Memory.test.ts
+++ b/src/adapters/Memory.test.ts
@@ -2,8 +2,7 @@ import { deepStrictEqual as deepEqual, strictEqual as equal } from 'assert'
 
 import { Memory } from './Memory.js'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function testMemory() {
+export async function testMemory(): Promise<void> {
   const obj = { a: 1 }
 
   const memory = new Memory()

--- a/src/adapters/Memory.test.ts
+++ b/src/adapters/Memory.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual as deepEqual, strictEqual as equal } from 'assert'
 
 import { Memory } from './Memory.js'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function testMemory() {
   const obj = { a: 1 }
 

--- a/src/adapters/MemorySync.test.ts
+++ b/src/adapters/MemorySync.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual as deepEqual, strictEqual as equal } from 'assert'
 
 import { MemorySync } from './MemorySync.js'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function testMemorySync() {
   const obj = { a: 1 }
 

--- a/src/adapters/MemorySync.test.ts
+++ b/src/adapters/MemorySync.test.ts
@@ -2,8 +2,7 @@ import { deepStrictEqual as deepEqual, strictEqual as equal } from 'assert'
 
 import { MemorySync } from './MemorySync.js'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function testMemorySync() {
+export function testMemorySync(): void {
   const obj = { a: 1 }
 
   const memory = new MemorySync()

--- a/src/adapters/TextFile.test.ts
+++ b/src/adapters/TextFile.test.ts
@@ -3,8 +3,7 @@ import tempy from 'tempy'
 
 import { TextFile } from './TextFile.js'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function testTextFile() {
+export async function testTextFile(): Promise<void> {
   const str = 'foo'
 
   const filename = tempy.file()
@@ -20,8 +19,7 @@ export async function testTextFile() {
   deepEqual(await file.read(), str)
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function testRaceCondition() {
+export async function testRaceCondition(): Promise<void> {
   const filename = tempy.file()
   const file = new TextFile(filename)
   const promises = []

--- a/src/adapters/TextFile.test.ts
+++ b/src/adapters/TextFile.test.ts
@@ -3,6 +3,7 @@ import tempy from 'tempy'
 
 import { TextFile } from './TextFile.js'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function testTextFile() {
   const str = 'foo'
 
@@ -19,6 +20,7 @@ export async function testTextFile() {
   deepEqual(await file.read(), str)
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function testRaceCondition() {
   const filename = tempy.file()
   const file = new TextFile(filename)

--- a/src/adapters/TextFileSync.test.ts
+++ b/src/adapters/TextFileSync.test.ts
@@ -3,6 +3,7 @@ import tempy from 'tempy'
 
 import { TextFileSync } from './TextFileSync.js'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
 export async function testTextFileSync() {
   const str = 'foo'
 

--- a/src/adapters/TextFileSync.test.ts
+++ b/src/adapters/TextFileSync.test.ts
@@ -3,8 +3,7 @@ import tempy from 'tempy'
 
 import { TextFileSync } from './TextFileSync.js'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/require-await
-export async function testTextFileSync() {
+export function testTextFileSync(): void {
   const str = 'foo'
 
   const filename = tempy.file()


### PR DESCRIPTION
There are two types of errors that should not be treated as errors, configure
eslint in the comments to ignore them.

1. @typescript-eslint/require-await, the code does not use await in async, but
we do want a Promise.
2. @typescript-eslint/explicit-module-boundary-types, there is no explicit
return statement in the function, but we really don't care about its return
value.

In order for eslint to make sense, I didn't disable these rules in the file
but to line.