### PR TITLE
fix: imported subpaths types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,18 @@
   "author": "Typicode <typicode@gmail.com>",
   "type": "module",
   "exports": {
-    ".": "./lib/index.js",
-    "./node": "./lib/node.js",
-    "./browser": "./lib/browser.js"
+    ".": {
+      "import": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./node": {
+      "import": "./lib/node.js",
+      "types": "./lib/node.d.ts"
+    },
+    "./browser": {
+      "import": "./lib/browser.js",
+      "types": "./lib/browser.d.ts"
+    }
   },
   "types": "lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -29,20 +29,21 @@
   "author": "Typicode <typicode@gmail.com>",
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./node": {
-      "import": "./lib/node.js",
-      "types": "./lib/node.d.ts"
-    },
-    "./browser": {
-      "import": "./lib/browser.js",
-      "types": "./lib/browser.d.ts"
+    ".": "./lib/index.js",
+    "./node": "./lib/node.js",
+    "./browser": "./lib/browser.js"
+  },
+  "types": "./lib",
+  "typesVersions": {
+    "*": {
+      "node": [
+        "lib/node.d.ts"
+      ],
+      "browser": [
+        "lib/browser.d.ts"
+      ]
     }
   },
-  "types": "lib",
   "files": [
     "lib",
     "!lib/examples/**/*",


### PR DESCRIPTION
## Problem

The problem itself is that in `node` module resolution, typescript can't import the subpaths' modules or the modules' types. The problem was not the modules but the types, as this works perfectly in Javascript without types. Investigating I found that there's no way to export many type files to include every type file for every subpath. I tried this at first:

```json
"exports": {
    ".": {
      "import": "./lib/index.js",
      "types": "./lib/index.d.ts"
    },
    "./node": {
      "import": "./lib/node.js",
      "types": "./lib/node.d.ts"
    },
    "./browser": {
      "import": "./lib/browser.js",
      "types": "./lib/browser.d.ts"
}
```

But the types weren't being exported. I tried to find the solution in the typescript documentation, but there's no article regarding subpaths, so I think there's no native support for subpath types.

## Solution

Finally, I found [this repository](https://github.com/teppeis/typescript-subpath-exports-workaround) that was addressing this particular case. It uses `typesVersions` to include many types for the other subpaths. It is a bit messy, but it's the only solution I had found for this case.

I ran this solution on these minimum reproduction repositories from #554:

- [GitHub - tkafka/lowdb-node-fail: A sample for lowdb issue: https://github.com/typicode/lowdb/issues/554](https://github.com/tkafka/lowdb-node-fail)
  
- [GitHub - minimusubi/cannot-find-lowdb](https://github.com/minimusubi/cannot-find-lowdb)
  
I also run this on my repository of my issue #568 and it solves it too.


So this solution gives compatibility for the `node` module resolution with typescript.