### PR TITLE
Return default data when JSON file is empty

### DIFF
--- a/src/adapters/node/JSONFile.ts
+++ b/src/adapters/node/JSONFile.ts
@@ -10,7 +10,7 @@ export class JSONFile<T> implements Adapter<T> {
 
   async read(): Promise<T | null> {
     const data = await this.#adapter.read()
-    if (data === null) {
+    if (!data) {
       return null
     } else {
       return JSON.parse(data) as T
@@ -31,7 +31,7 @@ export class JSONFileSync<T> implements SyncAdapter<T> {
 
   read(): T | null {
     const data = this.#adapter.read()
-    if (data === null) {
+    if (!data) {
       return null
     } else {
       return JSON.parse(data) as T


### PR DESCRIPTION
Currently, if the JSON file is empty, it throws a JSON parse error.

```
undefined:1

SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at JSONFile.read ←[90m(file:///C:/nodeapps/browser/←[39mnode_modules/←[4mlowdb←[24m/lib/adapters/node/JSONFile.js:25:25←[90m)←[39m
    at async Low.read ←[90m(file:///C:/nodeapps/browser/←[39mnode_modules/←[4mlowdb←[24m/lib/core/Low.js:26:22←[90m)←[39m
    at async ←[90mfile:///C:/nodeapps/browser/←[39mindex.js:8:1

Node.js v18.14.0
```

With this change, it would return the default data if the adapter returns a falsy value, which covers both non-existing files and empty files.

Falsy: `null`, `undefined`, `NaN`, `0` , `"" (empty string)`, `false`