### PR TITLE
Docs: Fixed outdated examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Adapters for reading and writing text. Useful for creating custom adapters.
 Adapters for easily supporting other data formats or adding behaviors (encrypt, compress...).
 
 ```js
-import { DataFile } from 'lowdb'
+import { DataFile } from 'lowdb/node'
 new DataFile(filename, {
   parse: YAML.parse,
   stringify: YAML.stringify

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ class CustomAsyncAdapter {
 }
 
 const adapter = new CustomAsyncAdapter()
-const db = new Low(adapter)
+const db = new Low(adapter, {})
 ```
 
 See [`src/adapters/`](src/adapters) for more examples.
@@ -390,7 +390,7 @@ class YAMLFile {
 }
 
 const adapter = new YAMLFile('file.yaml')
-const db = new Low(adapter)
+const db = new Low(adapter, {})
 ```
 
 ## Limits

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ class SyncAdapter {
 For example, let's say you have some async storage and want to create an adapter for it:
 
 ```js
+import { Low } from 'lowdb'
 import { api } from './AsyncStorage'
 
 class CustomAsyncAdapter {


### PR DESCRIPTION
In examples, fixed imports and added missing arguments in `Low` calls.