### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "exports": {
     ".": "./lib/index.js",
     "./node": "./lib/node.js",
-    "./browser": "./lib/browser.js"
+    "./browser": "./lib/browser.js",
+    "./lib/presets/node": "./lib/presets/node.js"
   },
   "types": "./lib",
   "typesVersions": {


### PR DESCRIPTION
Fix "Error: Package subpath './lib/presets/node' is not defined by "exports" in ~/node_modules/lowdb/package.json" bug