### PR TITLE
Change to README (edit: duplicate of #603)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ class LowWithLodash<T> extends Low<T> {
 const defaultData: Data = {
   posts: [],
 }
-const adapter = new JSONFile<Data>('db.json', defaultData)
+const adapter = new JSONFile<Data>('db.json')
 
-const db = new LowWithLodash(adapter)
+const db = new LowWithLodash(adapter, defaultData)
 await db.read()
 
 // Instead of db.data use db.chain to access lodash API


### PR DESCRIPTION
The `JSONFile()` constructor takes a filepath

```
const adapter = new JSONFile("db.json")
```

The `LowWithLodash()` constructor should accept `defaultData`.

```
new LowWithLodash(adapter, defaultData)
```

Just a small edit.